### PR TITLE
feat: change self study time config schema

### DIFF
--- a/src/resources/default.ts
+++ b/src/resources/default.ts
@@ -5,6 +5,7 @@ import {
   Grade,
   Class,
   NightTimeValues,
+  AfterschoolTimeValues,
 } from '../types';
 
 export const defaultPlaces = (() => {
@@ -74,20 +75,62 @@ export const defaultConfigs = {
     start: { hour: 7, minute: 0 },
     end: { hour: 8, minute: 15 },
   },
-  // 학년별 야자 진행 시간
-  [ConfigKeys.nightSelfStudyTimes]: [
+  // 학년별 자습 시간
+  [ConfigKeys.selfStudyTimes]: [
     null,
     {
-      [NightTimeValues[0]]: '19:50 - 21:10',
-      [NightTimeValues[1]]: '21:30 - 22:50',
+      [AfterschoolTimeValues[0]]: {
+        start: { hour: 17, minute: 5 },
+        end: { hour: 17, minute: 50 },
+      },
+      [AfterschoolTimeValues[1]]: {
+        start: { hour: 17, minute: 55 },
+        end: { hour: 18, minute: 35 },
+      },
+      [NightTimeValues[0]]: {
+        start: { hour: 19, minute: 50 },
+        end: { hour: 21, minute: 10 },
+      },
+      [NightTimeValues[1]]: {
+        start: { hour: 21, minute: 30 },
+        end: { hour: 22, minute: 50 },
+      },
     },
     {
-      [NightTimeValues[0]]: '19:50 - 21:10',
-      [NightTimeValues[1]]: '21:30 - 23:00',
+      [AfterschoolTimeValues[0]]: {
+        start: { hour: 17, minute: 5 },
+        end: { hour: 17, minute: 50 },
+      },
+      [AfterschoolTimeValues[1]]: {
+        start: { hour: 17, minute: 55 },
+        end: { hour: 18, minute: 35 },
+      },
+      [NightTimeValues[0]]: {
+        start: { hour: 19, minute: 50 },
+        end: { hour: 21, minute: 10 },
+      },
+      [NightTimeValues[1]]: {
+        start: { hour: 21, minute: 30 },
+        end: { hour: 23, minute: 0 },
+      },
     },
     {
-      [NightTimeValues[0]]: '19:50 - 21:10',
-      [NightTimeValues[1]]: '21:30 - 23:10',
+      [AfterschoolTimeValues[0]]: {
+        start: { hour: 17, minute: 5 },
+        end: { hour: 17, minute: 50 },
+      },
+      [AfterschoolTimeValues[1]]: {
+        start: { hour: 17, minute: 55 },
+        end: { hour: 18, minute: 35 },
+      },
+      [NightTimeValues[0]]: {
+        start: { hour: 19, minute: 50 },
+        end: { hour: 21, minute: 10 },
+      },
+      [NightTimeValues[1]]: {
+        start: { hour: 21, minute: 30 },
+        end: { hour: 23, minute: 10 },
+      },
     },
   ],
   // 자습 이동반 시행 여부 (코로나)

--- a/src/services/ingang-application/controllers.ts
+++ b/src/services/ingang-application/controllers.ts
@@ -32,7 +32,7 @@ const getApplicationsByClass = async (grade: number, klass: number) => (await In
   ));
 
 const getMaxApplicationPerClass = async (grade: number) => (await getConfig(ConfigKeys.ingangMaxApplicationPerClass))[grade];
-const getNightSelfStudyTimes = async (grade: number) => (await getConfig(ConfigKeys.nightSelfStudyTimes))[grade];
+const getSelfStudyTimes = async (grade: number) => (await getConfig(ConfigKeys.selfStudyTimes))[grade];
 
 export const getIngangApplicationStatus = async (req: Request, res: Response) => {
   const { _id: applier, grade, class: klass } = req.user;
@@ -40,7 +40,7 @@ export const getIngangApplicationStatus = async (req: Request, res: Response) =>
   const weeklyTicketCount = await getConfig(ConfigKeys.weeklyIngangTicketCount);
   const ingangMaxApplier = await getMaxApplicationPerClass(grade);
 
-  const nightSelfStudyTimes = await getNightSelfStudyTimes(grade);
+  const selfStudyTimes = await getSelfStudyTimes(grade);
   const ingangApplyPeriod = await getConfig(ConfigKeys.ingangApplyPeriod);
 
   const weeklyUsedTicket = await getWeeklyUsedTicket(applier);
@@ -53,7 +53,7 @@ export const getIngangApplicationStatus = async (req: Request, res: Response) =>
     weeklyRemainTicket,
     ingangMaxApplier,
     applicationsInClass,
-    nightSelfStudyTimes,
+    selfStudyTimes,
     ingangApplyPeriod,
   });
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@ export enum ConfigKeys {
   weeklyIngangTicketCount = 'WEEKLY_INGANG_TICKET_COUNT',
   ingangMaxApplicationPerClass = 'INGANG_MAX_APPLICATION_PER_CLASS',
   ingangApplyPeriod = 'INGANG_APPLY_PERIOD',
-  nightSelfStudyTimes = 'NIGHT_SELF_STUDY_TIMES',
+  selfStudyTimes = 'SELF_STUDY_TIMES',
   isMovingClassSystem = 'IS_MOVING_CLASS_SYSTEM',
 }
 


### PR DESCRIPTION
- `NIGHT_SELF_STUDY_TIMES` Key가 `SELF_STUDY_TIMES`로 변경됩니다.
- `SELF_STUDY_TIMES` 안에는 `AFSC1`, `AFSC2`, `NSS1`, `NSS2`가 있으며, 각각 시작 시간과 종료 시작 정보를 담고 있습니다.
- `SELF_STUDY_TIMES[1]`에는 1학년 자습 시간이 있으며, 2번, 3번 인덱스는 2학년, 3학년입니다. (0번 인덱스에는 명시적으로 null을 넣었습니다.)

[반영된 Config](https://api.dimigo.in/config)