### PR TITLE
feat: change URI of getClassStatus endpoint

### DIFF
--- a/src/services/attendance/index.ts
+++ b/src/services/attendance/index.ts
@@ -29,7 +29,7 @@ export default createService({
     },
     {
       method: 'get',
-      path: '/date/:date/grade/:grade/class/:class',
+      path: '/date/:date/grade/:grade/class/:class/status',
       needAuth: true,
       needPermission: false,
       handler: controllers.getClassStatus,


### PR DESCRIPTION
새로 생성된 타임라인 엔드포인트와 URI가 구분되도록 학급 현황 엔드포인트의 URI를 변경합니다.