### PR TITLE
동아리 신청 상태중 "registering" 상태 추가

### DIFF
--- a/src/services/circle/controllers.ts
+++ b/src/services/circle/controllers.ts
@@ -1,9 +1,15 @@
 import { Request, Response } from 'express';
 import { HttpException } from '../../exceptions';
 import { CircleModel, CircleApplicationModel } from '../../models';
+import { ConfigKeys, CirclePeriod } from '../../types';
+import { getConfig } from '../../resources/config';
 
 export const getAllCircles = async (req: Request, res: Response) => {
   const { user } = req;
+  const period = await getConfig(ConfigKeys.circlePeriod);
+  if (period === CirclePeriod.registering) {
+    res.json({ circles: [] });
+  }
   const appliedIds = (await CircleApplicationModel.findByApplier(user._id))
     .map((a) => a.circle.toString());
   const circles = await CircleModel.find()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export enum ConfigKeys {
 }
 
 export enum CirclePeriod {
+  registering = 'REGISTERING',
   application = 'APPLICATION',
   interview = 'INTERVIEW',
   final = 'FINAL',


### PR DESCRIPTION
@rycont (정한) 요청으로 작업하였습니다 

동아리 신청의 공정성을 위해 모든 동아리에 신청을 받고 한꺼번에 상태가 바뀌는 시점에 동아리 목록이 반환되도록 합니다.

상태가 registering일 경우 데이터베이스 값과 무관하게 /circle 에서

>  {"circles": []}

 와 같이 반환하도록 합니다