### PR TITLE
fix: afterschool count function change to mongodb 

### DIFF
--- a/src/middlewares/check-period.ts
+++ b/src/middlewares/check-period.ts
@@ -6,7 +6,9 @@ import { HttpException } from '../exceptions';
 import { getMinutesValue } from '../resources/date';
 
 export const checkAfterschoolApplyPeriod = async (req: Request, res: Response, next: NextFunction) => {
-  const applyPeriod = await getConfig(ConfigKeys.afterschoolApplyPeriod);
+  const userGrade = req.user.grade;
+  const applyPeriod = (await getConfig(ConfigKeys.afterschoolApplyPeriod))[userGrade - 1];
+
   const now = new Date();
   if (now < applyPeriod.start || applyPeriod.end < now) {
     throw new HttpException(403, '방과 후 수강 신청 기간이 아닙니다.');

--- a/src/services/afterschool/controllers.ts
+++ b/src/services/afterschool/controllers.ts
@@ -1,15 +1,15 @@
 import { Request, Response } from 'express';
 import { HttpException } from '../../exceptions';
-import {
-  getAfterschoolApplierCount,
-  removeAfterschoolApplierCount,
-} from '../../resources/redis';
+// import {
+//   getAfterschoolApplierCount,
+//   removeAfterschoolApplierCount,
+// } from '../../resources/redis';
 import { AfterschoolModel, AfterschoolApplicationModel } from '../../models';
 
 const applierCountMapper = async (afterschool: any) => {
-  const applierCount = await getAfterschoolApplierCount(
-    afterschool._id,
-  );
+  const applierCount = await AfterschoolApplicationModel.count({
+    afterschool: afterschool._id,
+  });
   return {
     ...(afterschool.toJSON()),
     applierCount,
@@ -62,7 +62,7 @@ export const deleteAfterschool = async (req: Request, res: Response) => {
     afterschool: afterschool._id,
   });
   await afterschool.deleteOne();
-  await removeAfterschoolApplierCount(afterschool._id);
+  // await removeAfterschoolApplierCount(afterschool._id);
   res.json({ afterschool });
 };
 


### PR DESCRIPTION
금일 (3월 17일) 발생한 방과후 관련 이슈에 대한 수정입니다.
1. 학년별 aftershcool period 를 추가하였습니다 
2. 기존 redis에서 가져오던 잔여 정원 을 데이터베이스의 afterschool Application의 갯수로 산정합니다.
3. 기존 빠져있던 로직인 신청 전 정원 체크 로직을 추가하였습니다.
